### PR TITLE
Added TALPA_ALLOW_NOCACHE response

### DIFF
--- a/include/talpa-vettingclient.h
+++ b/include/talpa-vettingclient.h
@@ -85,11 +85,11 @@ typedef enum
 typedef enum
 {
     TALPA_ALLOW = 0x0,
-    TALPA_ALLOW_NOCACHE,
     TALPA_DENY,
     TALPA_TIMEOUT,
     TALPA_ERROR,
-    TALPA_REQEXTDETAIL
+    TALPA_REQEXTDETAIL,
+    TALPA_ALLOW_NOCACHE
 } ETalpaProtocolResponse;
 
 

--- a/include/talpa-vettingclient.h
+++ b/include/talpa-vettingclient.h
@@ -85,6 +85,7 @@ typedef enum
 typedef enum
 {
     TALPA_ALLOW = 0x0,
+    TALPA_ALLOW_NOCACHE,
     TALPA_DENY,
     TALPA_TIMEOUT,
     TALPA_ERROR,

--- a/src/components/core/intercept_filters_impl/cache/cache_allow.c
+++ b/src/components/core/intercept_filters_impl/cache/cache_allow.c
@@ -95,6 +95,11 @@ static void examineFile(const void* self, IEvaluationReport* report, const IPers
         return;
     }
 
+    /* Do not cache the file if ALLOW_NOCACHE response received */
+    if ( report->noCacheResponse(report) )
+    {
+        return;
+    }
     /* If the access was allowed by an external vetting client add it to the cache */
     /* Do not cache the file if it is writable by somebody, unless it is only us. */
     if ( report->hasBeenExternallyVetted(report) &&

--- a/src/components/core/intercept_filters_impl/vetting_ctrl/vetting_ctrl.c
+++ b/src/components/core/intercept_filters_impl/vetting_ctrl/vetting_ctrl.c
@@ -2077,6 +2077,10 @@ static struct TalpaProtocolHeader* vettingResponse(void* self, VettingClient* cl
     dbg("[client %u-%u-%u] response %u", processParentPID(current), current->tgid, current->pid, packet->response);
     switch ( packet->response )
     {
+        case TALPA_ALLOW_NOCACHE:
+            job->report->setNoCacheResponse(job->report);
+            job->report->setRecommendedAction(job->report, EIA_Allow);
+            break;
         case TALPA_ALLOW:
             job->report->setRecommendedAction(job->report, EIA_Allow);
             break;

--- a/src/components/core/intercept_processing_impl/evaluation_report_impl.c
+++ b/src/components/core/intercept_processing_impl/evaluation_report_impl.c
@@ -37,6 +37,8 @@ static void             setErrorCode                (void* self, int errCode);
 static void             deleteEvaluationReportImpl  (struct tag_EvaluationReportImpl* object);
 static bool             hasBeenExternallyVetted     (const void* self);
 static void             externallyVetted            (void* self);
+static bool             noCacheResponse             (const void* self);
+static void             setNoCacheResponse          (void* self);
 /*
  * Template Object.
  */
@@ -53,6 +55,8 @@ static EvaluationReportImpl template_EvaluationReportImpl =
             setErrorCode,
             hasBeenExternallyVetted,
             externallyVetted,
+            noCacheResponse,
+            setNoCacheResponse,
             NULL,
             (void (*)(void*))deleteEvaluationReportImpl
         },
@@ -217,6 +221,17 @@ static bool hasBeenExternallyVetted(const void* self)
 static void externallyVetted(void* self)
 {
     this->mExternallyVetted = true;
+    return;
+}
+
+static bool noCacheResponse(const void* self)
+{
+    return this->mNoCacheResponse;
+}
+
+static void setNoCacheResponse(void* self)
+{
+    this->mNoCacheResponse = true;
     return;
 }
 /*

--- a/src/components/core/intercept_processing_impl/evaluation_report_impl.h
+++ b/src/components/core/intercept_processing_impl/evaluation_report_impl.h
@@ -47,6 +47,7 @@ typedef struct tag_EvaluationReportImpl
     int                 mTimeouts;
     int                 mError;
     bool                mExternallyVetted;
+    bool                mNoCacheResponse;
 } EvaluationReportImpl;
 
 /*

--- a/src/ifaces/intercept_filters/ievaluation_report.h
+++ b/src/ifaces/intercept_filters/ievaluation_report.h
@@ -35,6 +35,9 @@ typedef struct
     void                   (*setErrorCode)           (void* self, int errCode);
     bool                   (*hasBeenExternallyVetted)(const void* self);
     void                   (*externallyVetted)       (void* self);
+    bool                   (*noCacheResponse)        (const void* self);
+    void                   (*setNoCacheResponse)     (void* self);
+    /*
     /*
      *  Object supporting this interface instance.
      */


### PR DESCRIPTION
Added a new response as TALPA_ALLOW_NOCACHE, which can be used by vetting controller for the events which are not required to be cached.